### PR TITLE
Temporary change in get_import_dictionary

### DIFF
--- a/R/dictionary_functions.r
+++ b/R/dictionary_functions.r
@@ -14,10 +14,15 @@
 get_import_dictionary <- function(dataset, i, ft){
   x<- environment()
 
-  datasets_list<- list.files(system.file("data",package  = "microdadosBrasil"),pattern = "\\.rda") %>%
-                  gsub(pattern = "_dics\\.rda", replacement = "")
+#   datasets_list<- list.files(system.file("data",package  = "microdadosBrasil"),pattern = "\\.rda") %>%
+#                   gsub(pattern = "_dics\\.rda", replacement = "")
 
-  if(!dataset %in% datasets_list){stop( paste0("The available datasets are these: ",paste(datasets_list,collapse = ", ")),call. = FALSE)}
+
+  datasets_list<-c(
+  "CensoEducacaoSuperior" ,"CensoEscolar"        ,  "CensoIBGE"       ,      "PME"    ,
+   "PNAD"   ,               "PNADcontinua"      ,    "POF" )
+
+   if(!dataset %in% datasets_list){stop( paste0("The available datasets are these: ",paste(datasets_list,collapse = ", ")),call. = FALSE)}
 
 
   ref <- paste0(dataset,"_dics")

--- a/inst/extdata/PME_files_metadata_harmonization.csv
+++ b/inst/extdata/PME_files_metadata_harmonization.csv
@@ -1,4 +1,4 @@
-period;format;download_path;download_mode;path;missing_symbols;inputs_folder;data_folder;ft_PME
+period;format;download_path;download_mode;path;missing_symbols;inputs_folder;data_folder;ft_vinculos
 2002.01;fwf;ftp://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Microdados_reponderados/PMEnova_2002.zip;source;NA;NA;Documentacao/documentacao/Layout;PMEnova_2002;INPUT.txt&PMEnova.012002.txt
 2002.02;fwf;ftp://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Microdados_reponderados/PMEnova_2002.zip;source;NA;NA;Documentacao/documentacao/Layout;PMEnova_2002;INPUT.txt&PMEnova.022002.txt
 2002.03;fwf;ftp://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Microdados_reponderados/PMEnova_2002.zip;source;NA;NA;Documentacao/documentacao/Layout;PMEnova_2002;INPUT.txt&PMEnova.032002.txt


### PR DESCRIPTION
the function used to get names of the available datasets from .rda filenames. It happens that when the package is built this files are compressed and  the filenames change.

Until i can find a definitive solution for this matter, we should explicit dataset names inside the code, so the (important) function will work.

