### PR TITLE
correct get_available_datasets: full.name should be equal FALSE

### DIFF
--- a/R/auxiliar_functions.r
+++ b/R/auxiliar_functions.r
@@ -76,7 +76,7 @@ nodic_overlap <- function(dic, init_pos = "int_pos", fin_pos = "fin_pos"){
 #' Returns available datasets int the package
 #' @export
 get_available_datasets <- function(){
-  datasets_list<- list.files(system.file("extdata", package = "microdadosBrasil"), full.names = TRUE) %>%
+  datasets_list<- list.files(system.file("extdata", package = "microdadosBrasil"), full.names = FALSE) %>%
     (function(x) return(grep("metadata_harmonization",x, value = T))) %>%
     str_replace(pattern = "_.+", replacement = "") %>%
     str_replace(pattern = ".+/", replacement = "")


### PR DESCRIPTION
`download_sourceData()` fails for all datasets because of a bug in `get_available_datasets()`.
`list.files` option `full.names` should be equal to false. Otherwise, it also returns folder names. I am running Linux here. Maybe this is why I spot the problem, but I must say I don't know exactly how different folder structure among platforms should be treated.