### PR TITLE
RAIS updates to 2023

### DIFF
--- a/R/download_functions.R
+++ b/R/download_functions.R
@@ -168,48 +168,48 @@ download_sourceData <- function(dataset, i, unzip=T , root_path = NULL, replace 
       loop_counter = loop_counter + 1
     }}
     if (unzip==T & success == T){
-      #Won't use 'archive' in the main download function until its on CRAN
-      #Unzipping main source file:
-      #if(grepl(filename, pattern = "\\.7z")){
+      if(grepl(filename, pattern = "\\.7z")){
 
-       # archive::archive_extract(paste(c(root_path,filename),collapse = "/") , paste(c(root_path,file_dir),collapse = "/"))
-      #}else{
+        archive::archive_extract(paste(c(root_path,filename),collapse = "/") , paste(c(root_path,file_dir),collapse = "/"))
+      }else{
       unzip(paste(c(root_path,filename),collapse = "/") ,exdir = paste(c(root_path,file_dir),collapse = "/"))
-      #}
+      }
     }
 
 
   }
 
 
-    if (unzip==T & success == T){
-    ##unzipping the data files (in case not unziped above)
-    intern_files<- list.files(paste(c(root_path,file_dir),collapse = "/"), recursive = TRUE,all.files = TRUE, full.names = TRUE)
-    zip_files<- intern_files[grepl(pattern = "\\.zip$",x = intern_files)]
-    rar_files<- intern_files[grepl(pattern = "\\.rar$",x = intern_files)]
-    r7z_files<- intern_files[grepl(pattern = "\\.7z$",x = intern_files)]
-    if(length(r7z_files)>0){message(paste0("\nThere are files in .7z format inside the main folder, please unzip manually or use:\n unzip_all_7z_rar(", root_path, ")"))}
-    if(length(rar_files)>0){message(paste0("\nThere are files in .rar format inside the main folder, please unzip manually or use:\n unzip_all_7z_rar(", root_path, ")"))}
-    for(zip_file in zip_files){
-      exdir<- zip_file %>% gsub(pattern = "\\.zip", replacement = "")
-      unzip(zipfile = zip_file,exdir = exdir )
-    }
-    #for(zip_file in r7z_files){
-
-    # exdir<- zip_file %>% gsub(pattern = "\\.7z", replacement = "")
-    # archive::archive_extract(zip_file, exdir)
-
-    #}
-
-    #for(zip_file in rar_files){
-
-    #  exdir<- zip_file %>% gsub(pattern = "\\.rar", replacement = "")
-    #  archive::archive_extract(zip_file, exdir)
-
-    #}
 
 
-}
+  # if (unzip==T & success == T){
+  #
+  # #
+  # #   ##unzipping the data files (in case not unziped above)
+  #   intern_files<- list.files(paste(c(root_path,file_dir),collapse = "/"), recursive = TRUE,all.files = TRUE, full.names = TRUE)
+  #   zip_files<- intern_files[grepl(pattern = "\\.zip$",x = intern_files)]
+  #   rar_files<- intern_files[grepl(pattern = "\\.rar$",x = intern_files)]
+  #   r7z_files<- intern_files[grepl(pattern = "\\.7z$",x = intern_files)]
+  # #
+  #   for(zip_file in zip_files){
+  #     exdir<- zip_file %>% gsub(pattern = "\\.zip", replacement = "")
+  #     unzip(zipfile = zip_file,exdir = exdir )
+  #   }
+  #
+  # for(zip_file in r7z_files){
+  #   exdir <- zip_file %>% gsub(pattern = "\\.7z",replacement = "")
+  #   archive::archive_extract(zip_file,exdir)
+  # }
+  #   # check if package "archive" is installed before trying to extract the .rar files.
+  #   if(("archive" %in% installed.packages()[,1])){
+  #     for(zip_file in c(rar_files,r7z_files)){
+  #       exdir<- zip_file %>% gsub("\\.7z","",gsub(pattern = "\\.rar", replacement = ""))
+  #       archive::archive_extract(zip_file, exdir)
+  #       cat(paste0("Extracted ", zip_file,"\n"))
+  #     }
+  #   }
+  # }
+
 
   if(all(file.info(paste(c(root_path,filename),collapse = "/"))$isdir)){
 

--- a/R/import_wrapper_functions.R
+++ b/R/import_wrapper_functions.R
@@ -127,7 +127,7 @@ read_RAIS<- function(ft, i,root_path = NULL,file = NULL, vars_subset = NULL,UF =
   if(!is.null(UF)){
     UF <- paste0("(",paste(UF, collapse = "|"),")")
     metadata$ft_vinculos <- metadata$ft_vinculos %>%
-      gsub(pattern = "[A-Z]{2}", replacement = UF, fixed = TRUE)}
+      gsub(pattern = "\\[A-Z.*}", replacement = UF, fixed = F)}
 
 
   data <- read_data(dataset = "RAIS",ft = ft, i = i, metadata = metadata, root_path = root_path,file = file, vars_subset = vars_subset, nrows = nrows, source_file_mark = source_file_mark)

--- a/inst/extdata/RAIS_files_metadata_harmonization.csv
+++ b/inst/extdata/RAIS_files_metadata_harmonization.csv
@@ -32,4 +32,9 @@ period;format;download_path;download_mode;path;inputs_folder;data_folder;missing
 2015;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2015/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&ESTB2015.txt";";&(^|/)[A-Z]{2}2015.txt";
 2016;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2016/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&ESTB2016.txt";";&(^|/)[A-Z]{2}2016.txt";
 2017;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2017/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&ESTB2017.txt";";&(^|/)[A-Z]{2}2017.txt";
-2018;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2018/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&ESTB2018.txt";";&(^|/)[A-Z]{2}2018.txt";
+2018;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2018/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&RAIS_ESTAB_PUB.txt";";&(^|/)RAIS_VINC_PUB_[A-Z_]{2,15}.txt";
+2019;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2019/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&RAIS_ESTAB_PUB.txt";";&(^|/)RAIS_VINC_PUB_[A-Z_]{2,15}.txt";
+2020;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2020/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&RAIS_ESTAB_PUB.txt";";&(^|/)RAIS_VINC_PUB_[A-Z_]{2,15}.txt";
+2021;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2021/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&RAIS_ESTAB_PUB.txt";";&(^|/)RAIS_VINC_PUB_[A-Z_]{2,15}.txt";
+2022;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2022/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&RAIS_ESTAB_PUB.txt";";&(^|/)RAIS_VINC_PUB_[A-Z_]{2,15}.txt";
+2023;csv;ftp://ftp.mtps.gov.br/pdet/microdados/RAIS/2023/;ftp;;;;{&{ñ&{ñ&{ñc&{ñcl&{ñclas&{ñclass&{ñclass};";&RAIS_ESTAB_PUB.txt";";&(^|/)RAIS_VINC_PUB_[A-Z_]{2,15}.txt";


### PR DESCRIPTION
RAIS updates to 2023:

- archive package is on CRAN, enabled earlier commented code;
- adjust pattern (as is, recent years allow instead of UF, one of SP, SUL,NORTE,NORDESTE, MG_ES_RJ (recent layout of files made available by MTE);
- added 2019 to 2023 metadata harmonization file (fixed 2018)